### PR TITLE
change has_secure syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ or in your `Gemfile`
 Use it
 ------
 
+The attribute can be specified using either:
+
     class User < ActiveRecord::Base
       has_secure_security_answer
+    end
+
+or
+
+    class User < ActiveRecord::Base
+      has_secure :security_answer
     end
 
 In the above example:

--- a/lib/active_model/secure_attribute/has_secure_attribute.rb
+++ b/lib/active_model/secure_attribute/has_secure_attribute.rb
@@ -18,6 +18,10 @@ module ActiveModel
         end
       end
 
+      def has_secure(attr, opts={})
+        has_secure_attribute(attr, opts)
+      end
+
       def has_secure_attribute(meth, *args, &block)
         attribute_sym = meth.to_sym
         attr_reader attribute_sym # setter is defined later on

--- a/spec/models/has_secure_attribute_spec.rb
+++ b/spec/models/has_secure_attribute_spec.rb
@@ -182,3 +182,19 @@ describe TestModelWithAttributeDisableConfirmation do
     t.authenticate_security_answer('Answer').should eq t
   end
 end
+
+describe TestModelWithAlternativeSyntax do
+  it { should respond_to(:username)               }
+  it { should respond_to(:username=)              }
+  it { should respond_to(:username_confirmation)  }
+  it { should respond_to(:username_confirmation=) }
+  it { should respond_to(:authenticate_username)  }
+
+  context "with no validation" do
+    it { should respond_to(:security_answer)               }
+    it { should respond_to(:security_answer=)              }
+    it { should_not respond_to(:security_answer_confirmation)  }
+    it { should_not respond_to(:security_answer_confirmation=) }
+    it { should respond_to(:authenticate_security_answer)  }
+  end
+end

--- a/spec/models/test_model_with_alternative_syntax.rb
+++ b/spec/models/test_model_with_alternative_syntax.rb
@@ -1,0 +1,6 @@
+class TestModelWithAlternativeSyntax < ActiveRecord::Base
+  self.table_name = "test_model_with_attributes"
+
+  has_secure :username
+  has_secure :security_answer, validations: false
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require File.expand_path("../models/test_model_with_attribute_no_validation", __
 require File.expand_path("../models/test_model_with_attribute_protect_setter_for_digest", __FILE__)
 require File.expand_path("../models/test_model_with_attribute_with_case_sensitive", __FILE__)
 require File.expand_path("../models/test_model_with_attribute_disable_confirmation", __FILE__)
+require File.expand_path("../models/test_model_with_alternative_syntax", __FILE__)
 
 require 'factory_girl'
 FactoryGirl.find_definitions


### PR DESCRIPTION
In order to implement `has_secure_foo`, it requires that
`method_missing` be used.  This changes the syntax to `has_secure :foo`
which reads just as well, but uses an explicitly defined method.

Fixes #1
